### PR TITLE
Fixed build issues

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,5 +1,9 @@
 name: Testing pipeline
-on: [push]
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - 'master'
 jobs:
   Tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,20 +25,23 @@ jobs:
              sudo apt-get -y -qq install libssl-dev libkrb5-dev zlib1g
              wget -nv https://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.35.0/libuv1_1.35.0-1_amd64.deb
              sudo dpkg -i libuv1_1.35.0-1_amd64.deb
+             wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
+             sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
+             sudo apt-get -y -qq install libuv1 libuv1-dev
              wget -nv https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.15.3/cassandra-cpp-driver_2.15.3-1_amd64.deb
              sudo dpkg -i cassandra-cpp-driver_2.15.3-1_amd64.deb
              sudo apt-get -y -qq update
-             sudo apt-get -y -qq install curl libcurl4-openssl-dev python2
+             sudo apt-get -y -qq install curl libcurl4-openssl-dev python2 python3
              sudo dpkg -i ../external/prometheus-cpp_0.12.3_amd64.deb
       - name: Install Cassandra
         run: |
-             wget -nv https://dlcdn.apache.org/cassandra/4.0.4/apache-cassandra-4.0.4-bin.tar.gz
-             tar xzf apache-cassandra-4.0.4-bin.tar.gz
+             wget -nv https://dlcdn.apache.org/cassandra/4.1.0/apache-cassandra-4.1.0-bin.tar.gz
+             tar xzf apache-cassandra-4.1.0-bin.tar.gz
       - name: Tests
         run: |
-             apache-cassandra-4.0.4/bin/cassandra -R
-             sleep 40
-             apache-cassandra-4.0.4/bin/cqlsh -f ./testdata.cql
+             apache-cassandra-4.1.0/bin/cassandra -R
+             sleep 100
+             apache-cassandra-4.1.0/bin/cqlsh -f ./testdata.cql
              rm -rf database_build
              mkdir database_build
              cd database_build
@@ -56,16 +59,19 @@ jobs:
              sudo apt-get -y -qq update
              sudo apt-get -y -qq dist-upgrade
              sudo apt-get -y -qq install gcc g++ cmake autoconf dpkg wget git
-             sudo apt-get -y -qq install libboost-all-dev
+             sudo apt-get -y -qq install libboost-all-dev libuv1 libuv1-dev
              wget -nv http://archive.ubuntu.com/ubuntu/pool/main/g/glibc/multiarch-support_2.27-3ubuntu1.5_amd64.deb
              sudo dpkg -i multiarch-support_2.27-3ubuntu1.5_amd64.deb
              sudo apt-get -y -qq install libssl-dev libkrb5-dev zlib1g
              wget -nv https://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.35.0/libuv1_1.35.0-1_amd64.deb
              sudo dpkg -i libuv1_1.35.0-1_amd64.deb
+             sudo apt-get -y -qq install libuv1 libuv1-dev
+             wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
+             sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
              wget -nv https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.15.3/cassandra-cpp-driver_2.15.3-1_amd64.deb
              sudo dpkg -i cassandra-cpp-driver_2.15.3-1_amd64.deb
              sudo apt-get -y -qq update
-             sudo apt-get -y -qq install curl python2
+             sudo apt-get -y -qq install curl python2 python3
              sudo dpkg -i ../external/prometheus-cpp_0.12.3_amd64.deb
       - name: Install clang
         run: sudo apt-get -y -qq install clang clang-tidy clang-format

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,6 +27,7 @@ jobs:
              sudo dpkg -i libuv1_1.35.0-1_amd64.deb
              wget -nv https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.15.3/cassandra-cpp-driver_2.15.3-1_amd64.deb
              sudo dpkg -i cassandra-cpp-driver_2.15.3-1_amd64.deb
+             sudo apt-get -y -qq update
              sudo apt-get -y -qq install curl libcurl4-openssl-dev python
              sudo dpkg -i ../external/prometheus-cpp_0.12.3_amd64.deb
       - name: Install Cassandra
@@ -63,6 +64,7 @@ jobs:
              sudo dpkg -i libuv1_1.35.0-1_amd64.deb
              wget -nv https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.15.3/cassandra-cpp-driver_2.15.3-1_amd64.deb
              sudo dpkg -i cassandra-cpp-driver_2.15.3-1_amd64.deb
+             sudo apt-get -y -qq update
              sudo apt-get -y -qq install curl python
              sudo dpkg -i ../external/prometheus-cpp_0.12.3_amd64.deb
       - name: Install clang

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,7 +28,7 @@ jobs:
              wget -nv https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.15.3/cassandra-cpp-driver_2.15.3-1_amd64.deb
              sudo dpkg -i cassandra-cpp-driver_2.15.3-1_amd64.deb
              sudo apt-get -y -qq update
-             sudo apt-get -y -qq install curl libcurl4-openssl-dev python3
+             sudo apt-get -y -qq install curl libcurl4-openssl-dev python2
              sudo dpkg -i ../external/prometheus-cpp_0.12.3_amd64.deb
       - name: Install Cassandra
         run: |
@@ -65,7 +65,7 @@ jobs:
              wget -nv https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.15.3/cassandra-cpp-driver_2.15.3-1_amd64.deb
              sudo dpkg -i cassandra-cpp-driver_2.15.3-1_amd64.deb
              sudo apt-get -y -qq update
-             sudo apt-get -y -qq install curl python3
+             sudo apt-get -y -qq install curl python2
              sudo dpkg -i ../external/prometheus-cpp_0.12.3_amd64.deb
       - name: Install clang
         run: sudo apt-get -y -qq install clang clang-tidy clang-format

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,7 +28,7 @@ jobs:
              wget -nv https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.15.3/cassandra-cpp-driver_2.15.3-1_amd64.deb
              sudo dpkg -i cassandra-cpp-driver_2.15.3-1_amd64.deb
              sudo apt-get -y -qq update
-             sudo apt-get -y -qq install curl libcurl4-openssl-dev python
+             sudo apt-get -y -qq install curl libcurl4-openssl-dev python3
              sudo dpkg -i ../external/prometheus-cpp_0.12.3_amd64.deb
       - name: Install Cassandra
         run: |
@@ -65,7 +65,7 @@ jobs:
              wget -nv https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.15.3/cassandra-cpp-driver_2.15.3-1_amd64.deb
              sudo dpkg -i cassandra-cpp-driver_2.15.3-1_amd64.deb
              sudo apt-get -y -qq update
-             sudo apt-get -y -qq install curl python
+             sudo apt-get -y -qq install curl python3
              sudo dpkg -i ../external/prometheus-cpp_0.12.3_amd64.deb
       - name: Install clang
         run: sudo apt-get -y -qq install clang clang-tidy clang-format

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,4 +77,4 @@ ENDIF(CMAKE_BUILD_TYPE MATCHES Debug)
 configure_file(".env" ".env" COPYONLY)
 
 # Include sub-projects.
-# add_subdirectory ("tests")
+add_subdirectory ("tests")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.10.0
+  GIT_TAG        release-1.12.0
 )
 FetchContent_GetProperties(googletest)
 if(NOT googletest_POPULATED)


### PR DESCRIPTION
- Fixed dependency errors which was causing the build to fail
- Increased the sleep timeout in `Tests` segment
- Changed the Googletest version from v1.10.0 to v1.12.0. The older version was having issues.