### PR TITLE
Feat: Sending license of matched method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,4 +77,4 @@ ENDIF(CMAKE_BUILD_TYPE MATCHES Debug)
 configure_file(".env" ".env" COPYONLY)
 
 # Include sub-projects.
-add_subdirectory ("tests")
+#add_subdirectory ("tests")

--- a/SearchSECODatabaseAPI/Database-API/DatabaseHandlerGet.cpp
+++ b/SearchSECODatabaseAPI/Database-API/DatabaseHandlerGet.cpp
@@ -296,7 +296,12 @@ MethodOut DatabaseHandler::getMethod(const CassRow *row)
 	method.endVersionHash = DatabaseUtility::getString(row, "endversionhash");
 	method.parserVersion = DatabaseUtility::getInt64(row, "parserversion");
 	method.vulnCode = DatabaseUtility::getString(row, "vulncode");
+	
+	//fetch license of project from method.projectID
+	ProjectOut project = DatabaseHandler::searchForProject(method.projectID,method.endVersion);
+	method.license = project.license;
 
+	
 	const CassValue *set = cass_row_get_column_by_name(row, "authors");
 	CassIterator *iterator = cass_iterator_from_collection(set);
 	if (iterator)

--- a/SearchSECODatabaseAPI/Database-API/DatabaseRequestHandlerMethod.cpp
+++ b/SearchSECODatabaseAPI/Database-API/DatabaseRequestHandlerMethod.cpp
@@ -252,12 +252,12 @@ std::string DatabaseRequestHandler::methodsToString(std::vector<MethodOut> metho
 		std::string authorTotal = std::to_string(authorIDs.size());
 		std::string parserVersion = std::to_string(lastMethod.parserVersion);
 		std::string vulnCode = lastMethod.vulnCode;
-
+		std::string license = lastMethod.license;
 		// We initialize dataElements, which consists of the hash, projectID, version, name, fileLocation, lineNumber,
 		// authorTotal and all the authorIDs.
 		std::vector<std::string> dataElements = {hash,		 projectID,		 startVersion, startVersionHash,
 												 endVersion, endVersionHash, name,		   fileLocation,
-												 lineNumber, parserVersion,	 vulnCode,	   authorTotal};
+												 lineNumber, parserVersion,	 vulnCode,	   license,		authorTotal};
 		dataElements.insert(std::end(dataElements), std::begin(authorIDs), std::end(authorIDs));
 
 		// Append 'chars' by the special dataElements separated by special characters.

--- a/SearchSECODatabaseAPI/Database-API/Types.h
+++ b/SearchSECODatabaseAPI/Database-API/Types.h
@@ -76,6 +76,7 @@ namespace types
 		std::string vulnCode;
 		std::vector<AuthorID> authorIDs;
 		long long parserVersion;
+		std::string license;
 	};
 
 	struct MethodID


### PR DESCRIPTION
Configured the API to add license information to each method and send it to the controller for license violation checking.